### PR TITLE
Mle fix duplicates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.8 (unreleased)
 ------------------
 
+- Prevent duplicated userids.
+  [mathias.leimgruber]
+
 - Advanced sharing: disable right and left column in order to gain space.
   [jone]
 

--- a/ftw/permissionmanager/browser/copy_permissions.py
+++ b/ftw/permissionmanager/browser/copy_permissions.py
@@ -35,6 +35,8 @@ class CopyUserPermissionsView(BrowserView):
         if not search_term:
             return []
         results = []
+        userids = []
+        groupids = []
         hunter = getMultiAdapter((self.context, self.request),
                                   name='pas_search')
         # users
@@ -43,17 +45,21 @@ class CopyUserPermissionsView(BrowserView):
         for userinfo in users:
             userid = userinfo['userid']
             user = self.context.acl_users.getUserById(userid)
-            results.append(dict(id = userid,
-                             title = user.getProperty(
-                                'fullname') or user.getId() or userid,
-                             type = 'user'))
+            if userid not in userids:
+                results.append(dict(id=userid,
+                                    title=user.getProperty(
+                                    'fullname') or user.getId() or userid,
+                                    type='user'))
+                userids.append(userid)
         # groups
         for groupinfo in hunter.searchGroups(id=search_term):
             groupid = groupinfo['groupid']
             group = self.context.portal_groups.getGroupById(groupid)
-            results.append(dict(id = groupid,
-                             title = group.getGroupTitleOrName(),
-                             type = 'group'))
+            if groupid not in groupids:
+                results.append(dict(id=groupid,
+                                    title=group.getGroupTitleOrName(),
+                                    type='group'))
+                groupids.append(groupid)
         return results
 
     def source_user_title(self):

--- a/ftw/permissionmanager/tests/test_copy_permissions.py
+++ b/ftw/permissionmanager/tests/test_copy_permissions.py
@@ -8,11 +8,13 @@ from plone.testing.z2 import Browser
 import transaction
 
 
-
 class TestCopyPermissions(unittest.TestCase):
 
     layer = FTW_PERMISSIONMANAGER_INTEGRATION_TESTING
 
+    def setUp(self):
+        self.browser = Browser(self.layer['app'])
+        self.browser.handleErrors = False
 
     def test_copy_permission_view(self):
         portal = self.layer['portal']
@@ -20,7 +22,6 @@ class TestCopyPermissions(unittest.TestCase):
             (portal.folder1, portal.folder1.REQUEST),
             name="copy_user_permissions")
         self.assertTrue(view.__name__ == 'copy_user_permissions')
-
 
     def test_copy_permission_form_user(self):
         portal = self.layer['portal']
@@ -41,148 +42,175 @@ class TestCopyPermissions(unittest.TestCase):
             reindex=True)
         portal.folder1.folder2.reindexObjectSecurity()
 
-        transaction.commit() # for test browser
+        transaction.commit()  # for test self.browser
 
         # Login as test user
-        browser = Browser(self.layer['app'])
-        browser.open(portal_url + '/login_form')
-        browser.getControl(name='__ac_name').value = TEST_USER_NAME
-        browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
-        browser.getControl(name='submit').click()
+        self.browser.open(portal_url + '/login_form')
+        self.browser.getControl(name='__ac_name').value = TEST_USER_NAME
+        self.browser.getControl(
+            name='__ac_password').value = TEST_USER_PASSWORD
+        self.browser.getControl(name='submit').click()
 
-        browser.open(portal_url + '/folder1/copy_user_permissions')
+        self.browser.open(portal_url + '/folder1/copy_user_permissions')
 
         # Look for the right form
         self.assertIn(
-            '<form method="post" action="http://nohost/plone/folder1/@@copy_user_permissions">',
-            browser.contents)
+            '<form method="post" action="http://nohost/plone/folder1/'
+            '@@copy_user_permissions">',
+            self.browser.contents)
 
         # Search for the test user
-        browser.getControl(name="search_source_user").value = TEST_USER_ID
-        browser.getControl(name="submit").click()
+        self.browser.getControl(name="search_source_user").value = TEST_USER_ID
+        self.browser.getControl(name="submit").click()
         self.assertIn(
-            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_user_1_">test_user_1_</a>',
-            browser.contents)
+            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?'
+            'source_user=test_user_1_">test_user_1_</a>',
+            self.browser.contents)
 
         # Choose user
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_user_1_')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+                          'permissions?source_user=test_user_1_')
         self.assertIn(
             '<input type="hidden" name="source_user" value="test_user_1_" />',
-            browser.contents
+            self.browser.contents
         )
 
         # Choose target user
-        browser.getControl(name="search_target_user").value = TEST_USER_ID_2
-        browser.getControl(name="submit").click()
+        self.browser.getControl(
+            name="search_target_user").value = TEST_USER_ID_2
+        self.browser.getControl(name="submit").click()
         self.assertIn(
-            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?target_user=_test_user_2_&amp;source_user=test_user_1_">_test_user_2_</a>',
-            browser.contents
+            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?'
+            'target_user=_test_user_2_&amp;source_user=test_user_1_">'
+            '_test_user_2_</a>',
+            self.browser.contents
         )
 
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?target_user=_test_user_2_&amp;source_user=test_user_1_')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+                          'permissions?target_user=_test_user_2_&amp;'
+                          'source_user=test_user_1_')
 
         # Confirm link
         self.assertIn(
-            '<a class="context" href="http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_user_1_&amp;target_user=_test_user_2_&amp;confirm=1">',
-            browser.contents)
+            '<a class="context" href="http://nohost/plone/folder1/@@copy_'
+            'user_permissions?source_user=test_user_1_&amp;target_user='
+            '_test_user_2_&amp;confirm=1">',
+            self.browser.contents)
 
         # Abort link
         self.assertIn(
-            '<a class="standalone" href="http://nohost/plone/folder1/@@copy_user_permissions">',
-            browser.contents)
+            '<a class="standalone" href="http://nohost/plone/folder1/'
+            '@@copy_user_permissions">',
+            self.browser.contents)
 
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_user_1_&amp;target_user=_test_user_2_&amp;confirm=1')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+                          'permissions?source_user=test_user_1_&amp;target_'
+                          'user=_test_user_2_&amp;confirm=1')
 
         # After permission copy, redirect to copy permission view again
         self.assertIn(
             'class="template-copy_user_permissions',
-            browser.contents)
+            self.browser.contents)
 
         # Approve if test user 2 has the same local roles
         self.assertTrue(
-            portal.folder1.get_local_roles_for_userid(TEST_USER_ID_2) == ('Owner', 'Contributor'))
+            portal.folder1.get_local_roles_for_userid(TEST_USER_ID_2) ==
+                ('Owner', 'Contributor'))
         self.assertFalse(
-            portal.folder1.get_local_roles_for_userid(TEST_USER_ID_2) == ('Owner', 'Editor'))
-
-
+            portal.folder1.get_local_roles_for_userid(TEST_USER_ID_2) ==
+                ('Owner', 'Editor'))
 
     def test_copy_permission_form_group(self):
         portal = self.layer['portal']
         portal_url = portal.absolute_url()
 
-
         # Set up two groups
         portal.portal_groups.addGroup(TEST_GROUP_ID)
         portal.portal_groups.addGroup(TEST_GROUP_ID_2)
         # Add local roles
-        portal.folder1.manage_addLocalRoles(TEST_GROUP_ID, ['Contributor',])
+        portal.folder1.manage_addLocalRoles(TEST_GROUP_ID, ['Contributor', ])
         portal.folder1.reindexObjectSecurity()
-        portal.folder1.folder2.manage_addLocalRoles(TEST_GROUP_ID, ['Editor',])
+        portal.folder1.folder2.manage_addLocalRoles(TEST_GROUP_ID,
+                                                    ['Editor', ])
         portal.folder1.folder2.reindexObjectSecurity()
 
-        transaction.commit() # for test browser
+        transaction.commit()  # for test self.browser
 
         # Login as test user
-        browser = Browser(self.layer['app'])
-        browser.open(portal_url + '/login_form')
-        browser.getControl(name='__ac_name').value = TEST_USER_NAME
-        browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
-        browser.getControl(name='submit').click()
+        self.browser.open(portal_url + '/login_form')
+        self.browser.getControl(name='__ac_name').value = TEST_USER_NAME
+        self.browser.getControl(
+            name='__ac_password').value = TEST_USER_PASSWORD
+        self.browser.getControl(name='submit').click()
 
-        browser.open(portal_url + '/folder1/copy_user_permissions')
+        self.browser.open(portal_url + '/folder1/copy_user_permissions')
 
         # Look for the right form
         self.assertIn(
-            '<form method="post" action="http://nohost/plone/folder1/@@copy_user_permissions">',
-            browser.contents)
+            '<form method="post" action="http://nohost/plone/folder1/'
+            '@@copy_user_permissions">',
+            self.browser.contents)
 
         # Search for the test group
-        browser.getControl(name="search_source_user").value = TEST_GROUP_ID
-        browser.getControl(name="submit").click()
+        self.browser.getControl(
+            name="search_source_user").value = TEST_GROUP_ID
+        self.browser.getControl(name="submit").click()
         self.assertIn(
-            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_group">test_group</a>',
-            browser.contents)
+            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?'
+            'source_user=test_group">test_group</a>',
+            self.browser.contents)
 
         # Choose group
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_group')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+                          'permissions?source_user=test_group')
         self.assertIn(
             '<input type="hidden" name="source_user" value="test_group" />',
-            browser.contents
+            self.browser.contents
         )
 
         # Choose target user
-        browser.getControl(name="search_target_user").value = TEST_GROUP_ID_2
-        browser.getControl(name="submit").click()
+        self.browser.getControl(
+            name="search_target_user").value = TEST_GROUP_ID_2
+        self.browser.getControl(name="submit").click()
         self.assertIn(
-            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?target_user=test_group_2&amp;source_user=test_group">test_group_2</a>',
-            browser.contents
+            '<a href="http://nohost/plone/folder1/@@copy_user_permissions?'
+            'target_user=test_group_2&amp;source_user=test_group">'
+            'test_group_2</a>',
+            self.browser.contents
         )
 
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?target_user=test_group_2&amp;source_user=test_group')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+                          'permissions?target_user=test_group_2'
+                          '&amp;source_user=test_group')
 
         # Confirm link
         self.assertIn(
-            '<a class="context" href="http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_group&amp;target_user=test_group_2&amp;confirm=1">',
-            browser.contents)
+            '<a class="context" href="http://nohost/plone/folder1/@@copy_'
+            'user_permissions?source_user=test_group&amp;target_user='
+            'test_group_2&amp;confirm=1">',
+            self.browser.contents)
 
         # Abort link
         self.assertIn(
-            '<a class="standalone" href="http://nohost/plone/folder1/@@copy_user_permissions">',
-            browser.contents)
+            '<a class="standalone" href="http://nohost/plone/folder1/'
+            '@@copy_user_permissions">',
+            self.browser.contents)
 
-        browser.open('http://nohost/plone/folder1/@@copy_user_permissions?source_user=test_group&amp;target_user=test_group_2&amp;confirm=1')
+        self.browser.open('http://nohost/plone/folder1/@@copy_user_'
+            'permissions?source_user=test_group&amp;target_user='
+            'test_group_2&amp;confirm=1')
 
         # After permission copy, redirect to copy permission view again
         self.assertIn(
             'class="template-copy_user_permissions',
-            browser.contents)
+            self.browser.contents)
 
         for id_, roles in dict(portal.folder1.get_local_roles()).items():
             if id_ == TEST_GROUP_ID_2:
                 break
         self.assertIn('Contributor', roles)
-
-        for id_, roles in dict(portal.folder1.folder2.get_local_roles()).items():
+        results = dict(portal.folder1.folder2.get_local_roles()).items()
+        for id_, roles in results:
             if id_ == TEST_GROUP_ID_2:
                 break
         self.assertIn('Editor', roles)


### PR DESCRIPTION
The pas_search results sometimes contains duplicated user entries. 
I'm not sure what causing this. 
I think it has something to do with the ldap pas plugin and user enumeration on several other plugins (Like Properties plugin - Properties plugin also enumerates users)
