### PR TITLE
Use POST request for custom sharing view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make a POST request to the updateSharingInfo view.
+  [mathias.leimgruber]
 
 
 2.1.0 (2013-11-04)

--- a/ftw/permissionmanager/browser/sharing.pt
+++ b/ftw/permissionmanager/browser/sharing.pt
@@ -55,7 +55,7 @@
         $.ajax({
             url: $('base').attr('href') + '/@@updateSharingInfo',
             data: data,
-            type: 'GET',
+            type: 'POST',
             dataType: 'json',
             success: updateSharing
         });


### PR DESCRIPTION
currently it makes a GET request. 

If there are a lot of local roles defined, it exceeds the max GET request size. 
