### PR TITLE
Prevent from display a user twice in remove user permission search_result.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Prevent from display a user twice in remove user permission search_result.
+  [mathias.leimgruber]
 
 
 2.1.1 (2014-02-10)

--- a/ftw/permissionmanager/browser/remove_permissions.py
+++ b/ftw/permissionmanager/browser/remove_permissions.py
@@ -38,6 +38,7 @@ class RemoveUserPermissionsView(SharingView):
         if not search_term:
             return []
         results = []
+        userids = []
         hunter = getMultiAdapter((self.context, self.request),
                                  name='pas_search')
         # users
@@ -46,10 +47,12 @@ class RemoveUserPermissionsView(SharingView):
         for userinfo in users:
             userid = userinfo['userid']
             user = self.context.acl_users.getUserById(userid)
-            results.append(dict(id = userid,
-                             title = user.getProperty(
-                                 'fullname') or user.getId() or userid,
-                             type = 'user'))
+            if userid not in userids:
+                results.append(dict(id = userid,
+                                 title = user.getProperty(
+                                     'fullname') or user.getId() or userid,
+                                 type = 'user'))
+                userids.append(userid)
         # groups
         for groupinfo in hunter.searchGroups(id=search_term):
             groupid = groupinfo['groupid']

--- a/ftw/permissionmanager/tests/test_remove_permissions.py
+++ b/ftw/permissionmanager/tests/test_remove_permissions.py
@@ -1,9 +1,10 @@
-from zope.component import getMultiAdapter
 from ftw.permissionmanager.testing import FTW_PERMISSIONMANAGER_INTEGRATION_TESTING
-import unittest2 as unittest
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD, TEST_USER_ID
 from plone.testing.z2 import Browser
+from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 import transaction
+import unittest2 as unittest
 
 class TestRemovePermissions(unittest.TestCase):
 
@@ -143,3 +144,22 @@ class TestRemovePermissions(unittest.TestCase):
             TEST_GROUP_ID in [entry[0] for entry in portal.folder1.get_local_roles()])
         self.assertFalse(
             TEST_GROUP_ID in [entry[0] for entry in portal.folder1.folder2.get_local_roles()])
+
+    def test_user_is_not_twice_in_result_set(self):
+        portal = self.layer['portal']
+        portal.portal_registration.addMember(
+            'John.Doe',
+            'secret',
+            properties={'username': 'John.Doe',
+                        'fullname': 'John Doe',
+                        'email': 'john@doe.com'})
+
+        folder = portal['folder1']
+        folder.REQUEST.form['search_term'] = 'John'
+
+        view = queryMultiAdapter((folder, folder.REQUEST),
+                                 name='remove_user_permissions')
+
+        self.assertEquals(1,
+                          len(view.search_results()),
+                          'Expect to find only one user')


### PR DESCRIPTION
It was possible to have the same user twice in the result set. 
The `search_result` method searches twice, once for a userid and once for the fullname. 
The user appeared twice in the following case:
- Username: john.doe
- Fullname: John Does
- Search for 'john'

`john` matches in both cases. 
