### PR TITLE
Fix opening author view in a overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Fix opening author view in a overlay.
+  [mathias.leimgruber]
+
 - Prevent from display a user twice in remove user permission search_result.
   [mathias.leimgruber]
 

--- a/ftw/permissionmanager/browser/templates/sharing.pt
+++ b/ftw/permissionmanager/browser/templates/sharing.pt
@@ -19,7 +19,7 @@
                 $this = $(this);
                 $this.prepOverlay({
                     subtype:'ajax',
-                    urlmatch:'$',urlreplace:' .authorsInformation > *'
+                    urlmatch:'$',urlreplace:' #content > *'
                 });
                 //trigger click event
                $this.trigger('click');


### PR DESCRIPTION
@Tschanzt 
The filter criterion changed from Plone 4.0 to 4.3.x
I missed this in plone 4.3 compatibility PR.
