### PR TITLE
BugFix do not encode search_term, this leads to strange errors in the RAMCacheManager

### DIFF
--- a/ftw/permissionmanager/browser/principal_role_tree.py
+++ b/ftw/permissionmanager/browser/principal_role_tree.py
@@ -35,7 +35,7 @@ class SearchPrincipals(BrowserView):
         self.search_term = None
 
     def __call__(self):
-        self.search_term = self.request.get('search_term', '').decode('utf-8')
+        self.search_term = self.request.get('search_term', '')
 
         if not self.search_term:
             raise BadRequest('No search_term found.')


### PR DESCRIPTION
This only happens if we patch the LDAPUserFolder utils.py encoding to 'utf-8', instead of 'latin-1'.
