### PR TITLE
Fixed german copy permission translation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed german copy permission translation.
+  [lknoepfel]
 
 
 2.3.0 (2014-08-25)

--- a/ftw/permissionmanager/locales/de/LC_MESSAGES/ftw.permissionmanager.po
+++ b/ftw/permissionmanager/locales/de/LC_MESSAGES/ftw.permissionmanager.po
@@ -55,7 +55,7 @@ msgstr "Nach Benutzer/Gruppen suchen"
 #: ./ftw/permissionmanager/browser/templates/copy_user_permissions.pt:22
 #: ./ftw/permissionmanager/browser/templates/permission_manager.pt:43
 msgid "help_copy_permissions"
-msgstr "Berechtigungen eines Benutzers im ganzen Bereich auf einen anderen Benutzer Übertragen."
+msgstr "Berechtigungen eines Benutzers im ganzen Bereich auf einen anderen Benutzer übertragen."
 
 #. Default: "This section allows you to export and import security settings"
 #: ./ftw/permissionmanager/browser/templates/import_export_permissions.pt:21


### PR DESCRIPTION
Follow up to https://github.com/4teamwork/ftw.permissionmanager/pull/24.
Forgot to fix upper-case `Ü`.

![screen shot 2014-11-04 at 11 46 33](https://cloud.githubusercontent.com/assets/1375745/4898420/52f40892-6410-11e4-9b37-2ff392d496d2.png)

@maethu 
