### PR TITLE
CSV export: insert the users fullname in the "Name" column.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- CSV export: insert the users fullname in the "Name" column.
+  [jone]
 
 
 2.3.2 (2015-02-09)

--- a/ftw/permissionmanager/browser/import_export_permissions.py
+++ b/ftw/permissionmanager/browser/import_export_permissions.py
@@ -1,11 +1,12 @@
-import StringIO
-import csv
-from Products.Five import BrowserView
-from Products.statusmessages.interfaces import IStatusMessage
 from ftw.permissionmanager import permission_manager_factory as _
 from plone.app.workflow.interfaces import ISharingPageRole
-from zope.component import getUtilitiesFor
 from plone.memoize.instance import memoize
+from Products.CMFCore.utils import getToolByName
+from Products.Five import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
+from zope.component import getUtilitiesFor
+import csv
+import StringIO
 
 DEFAULT_ROLES = ['Owner', ]
 
@@ -20,6 +21,7 @@ class ImportExportPermissionsView(BrowserView):
         self.recursive = None
         self.relative_paths = None
         self.structure_only = None
+        self.portal_membership = getToolByName(self.context, 'portal_membership')
 
     def __call__(self, *args, **kwargs):
         self.request.set('disable_border', True)
@@ -92,8 +94,10 @@ class ImportExportPermissionsView(BrowserView):
             contextPath = '/'.join(self.context.getPhysicalPath())
             path = '...%s' % path[len(contextPath):]
         for user, roles in obj.get_local_roles():
+            member = self.portal_membership.getMemberById(user)
+            fullname = member and member.getProperty('fullname', user) or user
             row = {
-                'Name': user.encode(self.encoding),
+                'Name': fullname.decode('utf-8').encode(self.encoding),
                 'Userid': user.encode(self.encoding),
                 'Title': obj.Title().decode('utf-8').encode(self.encoding),
                 'Path': path,

--- a/ftw/permissionmanager/tests/test_export_import.py
+++ b/ftw/permissionmanager/tests/test_export_import.py
@@ -25,6 +25,8 @@ class TestCopyPermissions(unittest.TestCase):
             member_ids=[TEST_USER_ID_2],
             member_role="Reader",
             reindex=True)
+        member2 = portal.portal_membership.getMemberById(TEST_USER_ID_2)
+        member2.setMemberProperties({'fullname': 'Test \xc3\x9cser 2'})
 
         portal.portal_membership.setLocalRoles(
             obj=portal.folder1.folder2.document1,
@@ -111,6 +113,8 @@ class TestCopyPermissions(unittest.TestCase):
                 index = head.index('Reader')
                 self.assertEqual(
                     record[index], 'X')
+                self.assertEqual(['Test \xc3\x9cser 2', TEST_USER_ID_2],
+                                 record[:2])
             elif record[1] == TEST_USER_ID_2 and record[-1] == '/plone/folder1/folder2/document1':
                 index = head.index('Editor')
                 self.assertEqual(


### PR DESCRIPTION
Actually the "Name" and "Userid" both always contained the userid.
The "Name" column now contains the fullname.