### PR TITLE
Es 33 add dexterity support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add dexterity support for indexers
+  [elioschmutz]
 
 
 2.3.3 (2015-06-05)

--- a/ftw/permissionmanager/configure.zcml
+++ b/ftw/permissionmanager/configure.zcml
@@ -4,11 +4,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:monkey="http://namespaces.plone.org/monkey"
     i18n_domain="ftw.permissionmanager">
 
   <!-- include dependencies -->
   <include package="z3c.autoinclude" file="meta.zcml" />
+  <include package="ftw.upgrade" file="meta.zcml" />
+
   <includeDependencies package="." />
 
   <include package="ftw.profilehook" />
@@ -30,6 +33,11 @@
   <profilehook:hook
       profile="ftw.permissionmanager:default"
       handler=".hooks.installed"
+      />
+
+  <upgrade-step:directory
+      profile="ftw.permissionmanager:default"
+      directory="./upgrades"
       />
 
   <genericsetup:registerProfile

--- a/ftw/permissionmanager/indexer.py
+++ b/ftw/permissionmanager/indexer.py
@@ -1,26 +1,26 @@
-from Products.Archetypes.interfaces import IBaseObject
-from Products.CMFCore.utils import getToolByName
+from OFS.interfaces import IItem
 from plone.indexer import indexer
+from Products.CMFCore.utils import getToolByName
 
 
-@indexer(IBaseObject)
+@indexer(IItem)
 def global_get_local_roles(object):
     return object.get_local_roles()
 
 
-@indexer(IBaseObject)
+@indexer(IItem)
 def principal_with_local_roles(obj):
     return [user_roles[0] for user_roles in obj.get_local_roles()]
 
 
-@indexer(IBaseObject)
+@indexer(IItem)
 def isLocalRoleAcquired(object):
     if getattr(object, '__ac_local_roles_block__', None):
         return False
     return True
 
 
-@indexer(IBaseObject)
+@indexer(IItem)
 def workflow_id(obj):
     wftool = getToolByName(obj, 'portal_workflow')
     workflows = wftool.getWorkflowsFor(obj)

--- a/ftw/permissionmanager/profiles/default/metadata.xml
+++ b/ftw/permissionmanager/profiles/default/metadata.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2303</version>
 </metadata>

--- a/ftw/permissionmanager/upgrades/20150925150713_reindex_principal_with_local_roles_index_for_dexterity_support/upgrade.py
+++ b/ftw/permissionmanager/upgrades/20150925150713_reindex_principal_with_local_roles_index_for_dexterity_support/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexPrincipalWithLocalRolesIndexForDexteritySupport(UpgradeStep):
+    """Reindex principal with local roles index for dexterity support.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.catalog_rebuild_index('principal_with_local_roles')


### PR DESCRIPTION
@maethu @jone 

Add dexterity support for the indexers.

The `OFS.interfaces.IItem`is provided from both, dexterity and archetype objects.

closes #33 