### PR TITLE
Refactor reindexObjectSecurity patch to be less invasive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactor reindexObjectSecurity patch to be less invasive. [jone]
 
 
 2.4.0 (2015-12-29)

--- a/ftw/permissionmanager/__init__.py
+++ b/ftw/permissionmanager/__init__.py
@@ -1,3 +1,5 @@
+from Products.Archetypes import CatalogMultiplex
+from Products.CMFCore import CMFCatalogAware
 from zope.i18nmessageid import MessageFactory
 import csv
 
@@ -13,3 +15,17 @@ csv.register_dialect('excel_ger', excel_ger)
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""
+    register_local_roles_index()
+
+
+def register_local_roles_index():
+    name = 'principal_with_local_roles'
+    for klass in (CMFCatalogAware.CMFCatalogAware,
+                  CatalogMultiplex.CatalogMultiplex):
+
+        if name in klass._cmf_security_indexes:
+            continue
+
+        indexes = list(klass._cmf_security_indexes)
+        indexes.append(name)
+        klass._cmf_security_indexes = tuple(indexes)

--- a/ftw/permissionmanager/configure.zcml
+++ b/ftw/permissionmanager/configure.zcml
@@ -6,6 +6,7 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:monkey="http://namespaces.plone.org/monkey"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.permissionmanager">
 
   <include package="collective.monkeypatcher" />
@@ -55,11 +56,14 @@
       <adapter name="workflow_id" factory=".indexer.workflow_id" />
 
     <!-- Patches, using monkeypatcher -->
+    <!-- Let ftw.solr's reindexObjectSecurity be loaded first -->
+    <include zcml:condition="installed ftw.solr" package="ftw.solr" />
     <monkey:patch
         description="Also Update metadata on security reindex"
         class="Products.Archetypes.CatalogMultiplex.CatalogMultiplex"
         original="reindexObjectSecurity"
         replacement=".patches.permissionmanager_reindexObjectSecurity"
+        preserveOriginal="True"
         />
 
 </configure>

--- a/ftw/permissionmanager/patches.py
+++ b/ftw/permissionmanager/patches.py
@@ -1,48 +1,29 @@
-from Acquisition import aq_base
-from logging import WARNING
 from Products.Archetypes.config import TOOL_NAME
-from Products.Archetypes.log import log
 from Products.Archetypes.utils import isFactoryContained
 from Products.CMFCore.interfaces import ICatalogTool
 from Products.CMFCore.utils import getToolByName
 
 
 def permissionmanager_reindexObjectSecurity(self, skip_self=False):
+    # Execute standard object reindexing.
+    self._old_reindexObjectSecurity(skip_self=skip_self)
+
+    # The standard indexing does not update catalog metadata.
+    # We need to do that because we introduce security relevant
+    # catalog metadata in this package.
+
+    # In order to do that, we reindex the fast index "getId" of the
+    # current context, so that we can use `update_metadata=True`.
+    # We do not do that recursive because the metadata values
+    # are non-recursive.
     if isFactoryContained(self):
         return
     at = getToolByName(self, TOOL_NAME, None)
     if at is None:
         return
 
-    catalogs = [c for c in at.getCatalogsByType(self.meta_type)
-                if ICatalogTool.providedBy(c)]
-    path = '/'.join(self.getPhysicalPath())
+    catalogs = [catalog for catalog in at.getCatalogsByType(self.meta_type)
+                if ICatalogTool.providedBy(catalog)]
 
     for catalog in catalogs:
-        for brain in catalog.unrestrictedSearchResults(path=path):
-            brain_path = brain.getPath()
-            if brain_path == path and skip_self:
-                continue
-
-            # Get the object
-            if hasattr(aq_base(brain), '_unrestrictedGetObject'):
-                ob = brain._unrestrictedGetObject()
-            else:
-                # BBB: Zope 2.7
-                ob = self.unrestrictedTraverse(brain_path, None)
-            if ob is None:
-                # BBB: Ignore old references to deleted objects.
-                # Can happen only in Zope 2.7, or when using
-                # catalog-getObject-raises off in Zope 2.8
-                log("reindexObjectSecurity: Cannot get %s from catalog" %
-                    brain_path, level=WARNING)
-                continue
-            # PATCH: Append principal_with_local_roles index to security
-            # relevant indexes.
-            indexes = list(self._cmf_security_indexes)
-            indexes.append('principal_with_local_roles')
-            # Recatalog with the same catalog uid.
-            # PATCH: update_metadata=1, origin ist update_metadata=0.
-            # We add get_local_roles and isLocalRoleAcquired to the metadata
-            catalog.reindexObject(ob, idxs=tuple(indexes),
-                                  update_metadata=1, uid=brain_path)
+        catalog.reindexObject(self, idxs=['getId'], update_metadata=True)

--- a/ftw/permissionmanager/testing.py
+++ b/ftw/permissionmanager/testing.py
@@ -22,16 +22,14 @@ class FtwPermissionmanagerLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
-        # Load ZCML
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '</configure>',
+            context=configurationContext)
 
-        import ftw.permissionmanager
-        xmlconfig.file('configure.zcml',
-                       ftw.permissionmanager,
-                       context=configurationContext)
-
-        # installProduct() is *only* necessary for packages outside
-        # the Products.* namespace which are also declared as Zope 2 products,
-        # using <five:registerPackage /> in ZCML.
         z2.installProduct(app, 'ftw.permissionmanager')
 
     def setUpPloneSite(self, portal):


### PR DESCRIPTION
The patch now extends the original implementation and does no longer reimplement it completely.
Registering additional indexes is now done by patching the security indexes list.
This change adds solr compatibility.