### PR TITLE
Disable the right column on the @@sharing view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable the right column on @@sharing so it's content is not
+  covered by portlets in the right column. [mbaechtold]
 
 
 2.4.1 (2016-03-30)

--- a/ftw/permissionmanager/browser/sharing.py
+++ b/ftw/permissionmanager/browser/sharing.py
@@ -23,6 +23,13 @@ class SharingView(base):
     # template: Backward compatibility Plone < 4.3.2
     index = template = ViewPageTemplateFile('templates/sharing.pt')
 
+    def __call__(self, *args, **kwargs):
+        self.disable_right_column()
+        return super(SharingView, self).__call__(*args, **kwargs)
+
+    def disable_right_column(self):
+        self.request.set('disable_plone.rightcolumn', 1)
+
     def handle_form(self):
         if self.request.form.get('form.button.Save', None):
             # Clear the search form and hide the search results when the


### PR DESCRIPTION
This prevents the content of the @@sharing view to be covered by portlets in the right column.