### PR TITLE
Plone 5 compatible sharing view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Plone 5 compatibility with search view (working modals) [Nachtalb]
 
 
 3.0.1 (2020-01-15)

--- a/ftw/permissionmanager/browser/templates/sharing.pt
+++ b/ftw/permissionmanager/browser/templates/sharing.pt
@@ -13,8 +13,9 @@
 
         $(function(){
             // Use live binding for ajax loaded content
+            if ($.fn.prepOverlay === undefined) return;
             var $author_links = $('a.authorlink');
-            $author_links.live('click', function(e){
+            $author_links.on('click', function(e){
                 e.preventDefault();
                 $this = $(this);
                 $this.prepOverlay({
@@ -177,7 +178,7 @@
                                             <img tal:condition="not:is_group" tal:replace="structure context/user.png" />
                                             <a tal:attributes="href string:${context/portal_url}/author/${entry/id}"
                                                tal:content="entry/title"
-                                               class="authorlink"
+                                               class="authorlink pat-plone-modal"
                                                tal:omit-tag="is_group">
                                                 <!-- Member -->
                                             </a>
@@ -259,7 +260,7 @@
                                         <img tal:condition="not:is_group" tal:replace="structure context/user.png" />
                                         <a tal:attributes="href string:${portal_url}/author/${entry/id}"
                                            tal:content="entry/title"
-                                           class="authorlink"
+                                           class="authorlink pat-plone-modal"
                                            tal:omit-tag="is_group">
                                            <!-- Member -->
                                         </a>

--- a/ftw/permissionmanager/browser/templates/sharing.pt
+++ b/ftw/permissionmanager/browser/templates/sharing.pt
@@ -36,6 +36,13 @@
         $('.portalMessage').remove();
         $('#user-group-sharing').replaceWith(sharing);
         $('#content').prepend(messages);
+
+        // Apply modal pattern in case we are on Plone 5
+        if (typeof define === 'function' && define.amd) {
+          require(['jquery', 'pat-registry'], function($, Registry) {
+            Registry.scan($('.authorlink'));
+          })
+        }
     }
 
     // END copy of updateSharing method in kss-bbb.js


### PR DESCRIPTION
Fix the modals that relied on jquery tools `prepOverlay` and history version of jquery itself `.live()`.